### PR TITLE
Fix overwritten 0B file when no source files.

### DIFF
--- a/tasks/ejs.js
+++ b/tasks/ejs.js
@@ -14,6 +14,13 @@ module.exports = function(grunt) {
     grunt.verbose.writeflags(options, 'Options');
     this.files.forEach(function(file) {
       var out = file.src.map(grunt.file.read).join('');
+      if (file.src.length == 0) {
+        return;
+      }
+      if (file.src.length > 1) {
+        grunt.log.warn('Too many source files.');
+      }
+
       options.filename = file.src[0];
       grunt.file.write(file.dest, ejs.render(out, options));
       grunt.log.ok('Wrote ' + file.dest);


### PR DESCRIPTION
Fix destination file is overwritten when `file.src` has no source files. It happen in next case:

a configuring part of gruntfile.js
```js
ejs: {
  files: [{
    src: "sample.ejs",
    dest: "sample.html",
    filter: fn, // <-- filtering function
  }],
},
```