### PR TITLE
provide fresh copy of options, fixes #4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "ejs": "~1.0.0",
-    "underscore": "^1.7.0"
+    "ejs": "~1.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "ejs": "~1.0.0"
+    "ejs": "~1.0.0",
+    "underscore": "^1.7.0"
   },
   "devDependencies": {
     "grunt": "~0.4.0"

--- a/tasks/ejs.js
+++ b/tasks/ejs.js
@@ -9,13 +9,17 @@
 module.exports = function(grunt) {
   'use strict';
   var ejs = require('ejs');
+  var _ = require('underscore');
   grunt.registerMultiTask('ejs', 'compile ejs templates', function() {
     var options = this.options();
     grunt.verbose.writeflags(options, 'Options');
     this.files.forEach(function(file) {
+      // prevents options declared / overrided
+      // on file level to be moved to the next file
+      var freshOptions = _.extend({}, options);
       var out = file.src.map(grunt.file.read).join('');
-      options.filename = file.src[0];
-      grunt.file.write(file.dest, ejs.render(out, options));
+      freshOptions.filename = file.src[0];
+      grunt.file.write(file.dest, ejs.render(out, freshOptions));
       grunt.log.ok('Wrote ' + file.dest);
     })
   });

--- a/tasks/ejs.js
+++ b/tasks/ejs.js
@@ -9,18 +9,17 @@
 module.exports = function(grunt) {
   'use strict';
   var ejs = require('ejs');
-  var _ = require('underscore');
   grunt.registerMultiTask('ejs', 'compile ejs templates', function() {
     var options = this.options();
     grunt.verbose.writeflags(options, 'Options');
     this.files.forEach(function(file) {
       // prevents options declared / overrided
       // on file level to be moved to the next file
-      var freshOptions = _.extend({}, options);
+      var options = this.options();
       var out = file.src.map(grunt.file.read).join('');
-      freshOptions.filename = file.src[0];
-      grunt.file.write(file.dest, ejs.render(out, freshOptions));
+      options.filename = file.src[0];
+      grunt.file.write(file.dest, ejs.render(out, options));
       grunt.log.ok('Wrote ' + file.dest);
-    })
+    }, this);
   });
 };

--- a/tasks/ejs.js
+++ b/tasks/ejs.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
     this.files.forEach(function(file) {
       // prevents options declared / overrided
       // on file level to be moved to the next file
-      var options = this.options();
+      options = this.options();
       var out = file.src.map(grunt.file.read).join('');
       options.filename = file.src[0];
       grunt.file.write(file.dest, ejs.render(out, options));


### PR DESCRIPTION
this way every template will get a fresh copy of the `options` object, fixes #4 