### PR TITLE
process multiple glob files from src parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,16 @@
     "email": "kyle@dontkry.com",
     "url": "http://dontkry.com"
   },
+  "contributors": [
+    {
+      "name": "Kyle Robinson Young",
+      "email": "kyle@dontkry.com",
+      "url": "http://dontkry.com"
+    }, {
+      "name": "Stefan Grönke",
+      "email": "stefan@gronke.net"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/shama/grunt-ejs.git"

--- a/tasks/ejs.js
+++ b/tasks/ejs.js
@@ -6,20 +6,52 @@
  * Licensed under the MIT license.
  */
 
+var path = require('path');
+
 module.exports = function(grunt) {
   'use strict';
   var ejs = require('ejs');
   grunt.registerMultiTask('ejs', 'compile ejs templates', function() {
+
     var options = this.options();
     grunt.verbose.writeflags(options, 'Options');
+
     this.files.forEach(function(file) {
-      // prevents options declared / overrided
-      // on file level to be moved to the next file
-      options = this.options();
-      var out = file.src.map(grunt.file.read).join('');
-      options.filename = file.src[0];
-      grunt.file.write(file.dest, ejs.render(out, options));
-      grunt.log.ok('Wrote ' + file.dest);
+
+      var cwd = file.cwd || process.cwd();
+
+      file.src.forEach((sourceFile) => {
+
+        var src = path.join(cwd, sourceFile),
+            dest = file.dest;
+
+        if(file.ext && file.ext.length) {
+
+          var ext = file.ext;
+
+          // always begin with a dot
+          if(!ext.indexOf('.') === 0) {
+            ext = '.' + ext;
+          }
+
+          // remove .ejs suffix
+          dest = dest.replace(/\.ejs$/, '');
+
+          // remove already existing extension
+          dest = dest.replace(new RegExp('/\.' + file.ext + '$/'), '');
+
+          // append new extension
+          dest += file.ext;
+
+        }
+
+        var fileContent = grunt.file.read(src);
+        options.filename = sourceFile;
+        grunt.file.write(dest, ejs.render(fileContent, options));
+        grunt.log.ok('Wrote ' + dest);
+
+      });
+      
     }, this);
   });
 };


### PR DESCRIPTION
- support for processing multiple input files via `src` option glob pattern
- remove `.ejs` extension when `ext` option is specified
- do not add file extension when after removing `.ejs` the correct extension is already set