### PR TITLE
using the latest version of ejs (v3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ grunt.initConfig({
 
 ## Release History
 
-* 0.3.0 
+* 0.4.0
+  * update ejs to 3.0.2
+* 0.3.0
   * update ejs to 2.2.3
   * fix file options
 * 0.2.0 update ejs to 1.0.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ejs",
   "description": "A grunt task for rendering ejs templates.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "homepage": "https://github.com/shama/grunt-ejs",
   "author": {
     "name": "Kyle Robinson Young",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "ejs": "^2.2.3"
+    "ejs": "^3.0.2"
   },
   "devDependencies": {
     "grunt": "~0.4.0"


### PR DESCRIPTION
ejs which used by this plugin is older than the latest major version(v3).  I want to use the latest version, how about to update ejs version ?
https://github.com/mde/ejs/releases

I modified while referencing the following PRs.
* https://github.com/shama/grunt-ejs/pull/6
* https://github.com/shama/grunt-ejs/pull/7

I kindly ask for your confirmation.